### PR TITLE
ci: migrate to self-hosted runners (kill GHA billing)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: kvncrw-bitwarden-csi-provider
     steps:
       - uses: actions/checkout@v6
 
@@ -37,7 +37,7 @@ jobs:
         run: docker build --target builder .
 
   coverage:
-    runs-on: ubuntu-latest
+    runs-on: kvncrw-bitwarden-csi-provider
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   build-and-push:
-    runs-on: ubuntu-latest
+    runs-on: kvncrw-bitwarden-csi-provider
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## Why

Stops paying for GitHub-hosted Actions minutes on the personal kvncrw account. This repo's workflow(s) currently run on `ubuntu-latest` which is billed against the personal plan.

## What changed

Swapped `runs-on: ubuntu-latest` for the ARC AutoscalingRunnerSet label matching this repo's scale-set name (`kvncrw-<repo>`). GitHub-hosted runners are not used anywhere after this change.

## Required before merge

A matching AutoscalingRunnerSet MUST be deployed in the `cloudy-k3s` cluster (namespace `arc-runners`) before merging, otherwise jobs will queue forever. To add it, append an entry to `kvncrw/homelab/argo/charts/arc-runners/values.yaml` under `scaleSets:`:

```yaml
- name: kvncrw-<REPO-NAME>
  githubConfigUrl: https://github.com/kvncrw/<REPO-NAME>
  bwsSecretId: "ed0c3cb3-9ff9-42ba-83e9-b41300cd4f8a"
```

Argo CD will sync the new scale set; it will use the default runner image (`ghcr.io/actions/actions-runner:latest` with dind sidecar), which is sufficient for the standard Docker/Rust/Node builds in this repo.

## Not in scope

- Opening the PR to add the scale-set entry in `kvncrw/homelab` — do that separately.
- Merging — hold until the runner is registered.

## Alternative

If you'd rather not run this repo's CI at all (lower-value/archival), close this PR and delete or disable the workflow instead.
